### PR TITLE
Keep current rules when playing again

### DIFF
--- a/GameScenes/BattleResults/PlayAgain.gd
+++ b/GameScenes/BattleResults/PlayAgain.gd
@@ -1,4 +1,4 @@
 extends Label
 
 func callback():
-	SceneManager.goto_scene("res://GameScenes/Game/Game.tscn")
+	SceneManager.goto_scene("res://GameScenes/Game/Game.tscn", GlobalState.current_rules)

--- a/GameScenes/Menu/SinglePlayerMenu/Start.gd
+++ b/GameScenes/Menu/SinglePlayerMenu/Start.gd
@@ -6,4 +6,5 @@ func callback():
 	for node in get_parent().get_children():
 		if node is CheckButton:
 			rules[node.name] = node.pressed
+	GlobalState.current_rules = rules
 	SceneManager.goto_scene("res://GameScenes/Game/Game.tscn", rules)

--- a/Globals/GlobalState.gd
+++ b/Globals/GlobalState.gd
@@ -7,6 +7,7 @@ var matches_stats = {
 	"drawn": 0
 } setget set_matches_stats, get_matches_stats
 
+var current_rules = {}
 
 signal matches_stats_changed
 


### PR DESCRIPTION
Quick fix in reference to issue  #8 

Changes:
- added a current_rule variable to store the current set of rules in GlobalState.gd
- when creating the rule dictionary in Start.gd, update the current_rules
- pass the current rules as argument in PlayAgain.gd when calling the new game scene